### PR TITLE
Chore/remove unused dependency

### DIFF
--- a/.changeset/cyan-baths-taste.md
+++ b/.changeset/cyan-baths-taste.md
@@ -1,0 +1,5 @@
+---
+"@vtex/ads-core": patch
+---
+
+Remove unused dependency (diagnostics-web)

--- a/.changeset/cyan-baths-taste.md
+++ b/.changeset/cyan-baths-taste.md
@@ -1,5 +1,0 @@
----
-"@vtex/ads-core": patch
----
-
-Remove unused dependency (diagnostics-web)

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Patch Changes
 
-- 8bedc97: Remove unused dependency (diagnostics-web)
+- 8bedc97: Remove unused dependency (`@vtex/diagnostics-web`)
 
 ## 0.5.0
 

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @vtex/ads-core
 
+## 0.5.1
+
+### Patch Changes
+
+- 8bedc97: Remove unused dependency (diagnostics-web)
+
 ## 0.5.0
 
 ### Minor Changes

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@vtex/ads-core",
   "type": "module",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "scripts": {
     "build": "tsup",
     "clean": "rimraf dist",


### PR DESCRIPTION
## Summary

Prepares a new version to release without the unused `@vtex/diagnostics-web` dependency from `@vtex/ads-core`.

## Why

Versions `0.4.0` and `0.5.0` of `@vtex/ads-core` were published with an unnecessary dependency that is no longer used in the current codebase.

## Release plan

- Publish a new fixed version of `@vtex/ads-core`
- Deprecate `@vtex/ads-core@0.4.0`
- Deprecate `@vtex/ads-core@0.5.0`
