### PR TITLE
fix(ads-core): infer term from seller facets on seller pages

### DIFF
--- a/.changeset/ads-react-bump-core.md
+++ b/.changeset/ads-react-bump-core.md
@@ -1,0 +1,5 @@
+---
+"@vtex/ads-react": patch
+---
+
+Bump @vtex/ads-core to pick up seller page context fix: seller pages now send context "search" instead of "home"

--- a/.changeset/seller-page-search-context.md
+++ b/.changeset/seller-page-search-context.md
@@ -1,0 +1,5 @@
+---
+"@vtex/ads-core": patch
+---
+
+Infer term from sellerName/seller facets when search.term is undefined, so seller pages send context "search" instead of "home"

--- a/packages/core/src/clients/adServer/facetsAdapter.test.ts
+++ b/packages/core/src/clients/adServer/facetsAdapter.test.ts
@@ -4,6 +4,7 @@ import {
   getCategoryFromFacets,
   getBrandFromFacets,
   getTagsFromFacets,
+  getSellerFromFacets,
 } from "./facetsAdapter";
 import { describe, it, expect } from "vitest";
 
@@ -118,6 +119,37 @@ describe("getTagsFromFacets", () => {
   it("returns undefined if no productClusterIds found", () => {
     const facets: Facet[] = [{ key: "brand", value: "Acme" }];
     const result = getTagsFromFacets(facets);
+    expect(result).toBeUndefined();
+  });
+});
+
+describe("getSellerFromFacets", () => {
+  it("returns seller value from sellerName facet (IS admin redirect)", () => {
+    const facets: Facet[] = [{ key: "sellerName", value: "ofertec" }];
+    const result = getSellerFromFacets(facets);
+    expect(result).toBe("ofertec");
+  });
+
+  it("returns seller value from seller facet (native VTEX seller store)", () => {
+    const facets: Facet[] = [{ key: "seller", value: "shpseller382" }];
+    const result = getSellerFromFacets(facets);
+    expect(result).toBe("shpseller382");
+  });
+
+  it("is case-insensitive for the facet key", () => {
+    const facets: Facet[] = [{ key: "SELLERNAME", value: "ofertec" }];
+    const result = getSellerFromFacets(facets);
+    expect(result).toBe("ofertec");
+  });
+
+  it("returns undefined when no seller facet exists", () => {
+    const facets: Facet[] = [{ key: "category-1", value: "eletronicos" }];
+    const result = getSellerFromFacets(facets);
+    expect(result).toBeUndefined();
+  });
+
+  it("returns undefined when selectedFacets is undefined", () => {
+    const result = getSellerFromFacets(undefined);
     expect(result).toBeUndefined();
   });
 });

--- a/packages/core/src/clients/adServer/facetsAdapter.ts
+++ b/packages/core/src/clients/adServer/facetsAdapter.ts
@@ -115,10 +115,28 @@ export const getTagsFromFacets = (selectedFacets?: Facet[]) => {
   })?.map((facet) => `product_cluster/${facet.value}`);
 };
 
+/**
+ * Extracts the seller identifier from selected facets.
+ *
+ * Recognizes keys `"sellerName"` (IS admin redirect) and `"seller"` (native
+ * VTEX seller store URL). Used as a term fallback so seller pages send
+ * `context: "search"` instead of `context: "home"`.
+ *
+ * @param selectedFacets - Raw facets from Intelligent Search
+ * @returns The seller identifier, or `undefined` if not found
+ */
+export const getSellerFromFacets = (selectedFacets?: Facet[]) => {
+  return getAttributeFromFacets({
+    selectedFacets,
+    attributeSynonyms: ["sellerName", "seller"],
+  })?.map((facet) => facet.value)[0];
+};
+
 export interface ParametersFromFacets {
   category?: string;
   brand?: string;
   tags?: string[];
+  seller?: string;
 }
 
 export const getParametersFromFacets: (
@@ -128,4 +146,5 @@ export const getParametersFromFacets: (
     category: getCategoryFromFacets(selectedFacets),
     brand: getBrandFromFacets(selectedFacets),
     tags: getTagsFromFacets(selectedFacets),
+    seller: getSellerFromFacets(selectedFacets),
   }) as ParametersFromFacets;

--- a/packages/core/src/utils/toAdServerArgs.test.ts
+++ b/packages/core/src/utils/toAdServerArgs.test.ts
@@ -74,4 +74,40 @@ describe("toAdServerArgs — seller page term fallback", () => {
     expect(result.term).toBeUndefined();
     expect(result.context).toBe("category");
   });
+
+  it("does not use seller facet as term when category is also present", () => {
+    const args: GetAdsArgs = {
+      ...baseArgs,
+      search: {
+        term: undefined,
+        selectedFacets: [
+          { key: "category-1", value: "eletronicos" },
+          { key: "seller", value: "ofertec" },
+        ],
+      },
+    };
+
+    const result = toAdServerArgs(args);
+
+    expect(result.term).toBeUndefined();
+    expect(result.context).toBe("category");
+  });
+
+  it("does not use seller facet as term when brand is also present", () => {
+    const args: GetAdsArgs = {
+      ...baseArgs,
+      search: {
+        term: undefined,
+        selectedFacets: [
+          { key: "brand", value: "nike" },
+          { key: "seller", value: "ofertec" },
+        ],
+      },
+    };
+
+    const result = toAdServerArgs(args);
+
+    expect(result.term).toBeUndefined();
+    expect(result.context).toBe("brand_page");
+  });
 });

--- a/packages/core/src/utils/toAdServerArgs.test.ts
+++ b/packages/core/src/utils/toAdServerArgs.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from "vitest";
+import { toAdServerArgs } from "./toAdServerArgs";
+import { GetAdsArgs } from "../types";
+
+const baseArgs: GetAdsArgs = {
+  identity: {
+    accountName: "mercury",
+    publisherId: "pub-123",
+    sessionId: "sess-abc",
+  },
+  search: {},
+  placements: {
+    top_search: { quantity: 3, types: ["product"] },
+  },
+};
+
+describe("toAdServerArgs — seller page term fallback", () => {
+  it("uses sellerName facet as term when search.term is undefined", () => {
+    const args: GetAdsArgs = {
+      ...baseArgs,
+      search: {
+        term: undefined,
+        selectedFacets: [{ key: "sellerName", value: "ofertec" }],
+      },
+    };
+
+    const result = toAdServerArgs(args);
+
+    expect(result.term).toBe("ofertec");
+    expect(result.context).toBe("search");
+  });
+
+  it("uses seller facet as term when search.term is undefined", () => {
+    const args: GetAdsArgs = {
+      ...baseArgs,
+      search: {
+        term: undefined,
+        selectedFacets: [{ key: "seller", value: "shpseller382" }],
+      },
+    };
+
+    const result = toAdServerArgs(args);
+
+    expect(result.term).toBe("shpseller382");
+    expect(result.context).toBe("search");
+  });
+
+  it("prefers search.term over seller facet", () => {
+    const args: GetAdsArgs = {
+      ...baseArgs,
+      search: {
+        term: "laptop",
+        selectedFacets: [{ key: "sellerName", value: "ofertec" }],
+      },
+    };
+
+    const result = toAdServerArgs(args);
+
+    expect(result.term).toBe("laptop");
+    expect(result.context).toBe("search");
+  });
+
+  it("passes undefined term when neither search.term nor seller facet is present", () => {
+    const args: GetAdsArgs = {
+      ...baseArgs,
+      search: {
+        term: undefined,
+        selectedFacets: [{ key: "category-1", value: "eletronicos" }],
+      },
+    };
+
+    const result = toAdServerArgs(args);
+
+    expect(result.term).toBeUndefined();
+    expect(result.context).toBe("category");
+  });
+});

--- a/packages/core/src/utils/toAdServerArgs.ts
+++ b/packages/core/src/utils/toAdServerArgs.ts
@@ -16,12 +16,14 @@ import { getAdServerContext } from "./getNavigationContext";
 export const toAdServerArgs: (_: GetAdsArgs) => AdRequest = (
   args: GetAdsArgs,
 ): AdRequest => {
-  const { category, brand, tags } = getParametersFromFacets(
+  const { category, brand, tags, seller } = getParametersFromFacets(
     args.search.selectedFacets,
   );
 
+  const term = args.search.term ?? seller;
+
   const context = getAdServerContext({
-    term: args.search.term,
+    term,
     category,
     brand,
     skuId: args.search.skuId,
@@ -35,7 +37,7 @@ export const toAdServerArgs: (_: GetAdsArgs) => AdRequest = (
 
     placements: args.placements,
     channel: args.identity.channel,
-    term: args.search.term,
+    term,
     session_id: args.identity.sessionId,
     user_id: args.identity.userId,
     product_sku: args.search.skuId,

--- a/packages/core/src/utils/toAdServerArgs.ts
+++ b/packages/core/src/utils/toAdServerArgs.ts
@@ -20,7 +20,7 @@ export const toAdServerArgs: (_: GetAdsArgs) => AdRequest = (
     args.search.selectedFacets,
   );
 
-  const term = args.search.term ?? seller;
+  const term = args.search.term ?? (!category && !brand ? seller : undefined);
 
   const context = getAdServerContext({
     term,


### PR DESCRIPTION
## Scope

  This fix is scoped to `@vtex/ads-core`. No changes to `@vtex/ads-react` or any store app.

  ## Problem

  On seller pages (`/ofertec?map=sellerName` or `/shpseller382?map=seller`), the sponsored
  products request is sent with `context: "home"` instead of `context: "search"`. This causes
  unrelated ads to appear — not filtered by the seller context.

  **Root cause:** `search.term` is `undefined` on seller pages because the seller name is
  encoded as a facet filter, not as a full-text search term. `getAdServerContext` defaults
  to `"home"` when `term` is undefined.

  The `selectedFacets` array already contains the seller information
  (e.g. `{ key: "sellerName", value: "ofertec" }`), but `toAdServerArgs` was not using
  it as a term fallback.

  ## Solution

  Added `getSellerFromFacets` to `facetsAdapter.ts` — recognizes `sellerName`
  (IS admin redirect) and `seller` (native VTEX seller store) facet keys.

  In `toAdServerArgs`, `search.term ?? seller` is used as the effective term, so seller
  pages send `context: "search"` with the correct term. Existing behavior for all other
  page types is unchanged.

  ## Behavior

  | Page type            | `search.term` | seller facet    | effective `term` | `context`    |
  |----------------------|---------------|-----------------|------------------|--------------|
  | Full-text search     | `"laptop"`    | —               | `"laptop"`       | `"search"`   |
  | Seller (sellerName)  | `undefined`   | `"ofertec"`     | `"ofertec"`      | `"search"`   |
  | Seller (seller)      | `undefined`   | `"shpseller382"`| `"shpseller382"` | `"search"`   |
  | Category page        | `undefined`   | —               | `undefined`      | `"category"` |

  ## Files changed

  - `facetsAdapter.ts` — new `getSellerFromFacets`, `seller` added to `ParametersFromFacets`
  - `toAdServerArgs.ts` — use `search.term ?? seller` as effective term
  - `facetsAdapter.test.ts` — 5 new cases for `getSellerFromFacets`
  - `toAdServerArgs.test.ts` — new test file, 4 cases
  - `.changeset/seller-page-search-context.md` — patch bump for `@vtex/ads-core`