### PR TITLE
chore: add npm-publish-v1 pipeline and publish-npm workflow

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -3,20 +3,14 @@ name: Publish from CodeArtifact to npm
 on:
   workflow_dispatch:
     inputs:
-      package:
-        description: "Package to publish"
-        required: true
-        type: choice
-        options:
-          - "@vtex/ads-core"
-          - "@vtex/ads-react"
       version:
-        description: "Package version (e.g. 1.2.3)"
+        description: "Full tag name (e.g. @vtex/ads-core@1.2.3)"
         required: true
         type: string
       environment:
         description: "Environment (production or beta)"
-        required: true
+        required: false
+        default: production
         type: choice
         options:
           - production
@@ -51,6 +45,21 @@ jobs:
         with:
           node-version: "24"
 
+      - name: Parse package name and version from tag
+        id: parse
+        run: |
+          set -euo pipefail
+          TAG="${{ github.event.inputs.version }}"
+          # Tag format: @vtex/ads-core@0.5.2
+          # Extract package name (everything before the last @)
+          PACKAGE_NAME="${TAG%@*}"
+          # Extract version (everything after the last @)
+          PACKAGE_VERSION="${TAG##*@}"
+
+          echo "package_name=${PACKAGE_NAME}" >> $GITHUB_OUTPUT
+          echo "package_version=${PACKAGE_VERSION}" >> $GITHUB_OUTPUT
+          echo "Parsed: ${PACKAGE_NAME}@${PACKAGE_VERSION}"
+
       - name: Configure npm for CodeArtifact
         run: |
           set -euo pipefail
@@ -72,11 +81,11 @@ jobs:
       - name: Download package from CodeArtifact
         run: |
           set -euo pipefail
-          NPM_PACKAGE_NAME="${{ github.event.inputs.package }}"
-          VERSION="${{ github.event.inputs.version }}"
+          PACKAGE_NAME="${{ steps.parse.outputs.package_name }}"
+          PACKAGE_VERSION="${{ steps.parse.outputs.package_version }}"
 
-          echo "Downloading ${NPM_PACKAGE_NAME}@${VERSION} from CodeArtifact..."
-          npm pack "${NPM_PACKAGE_NAME}@${VERSION}"
+          echo "Downloading ${PACKAGE_NAME}@${PACKAGE_VERSION} from CodeArtifact..."
+          npm pack "${PACKAGE_NAME}@${PACKAGE_VERSION}"
 
           echo "Generated files:"
           ls -1 *.tgz

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -4,29 +4,29 @@ on:
   workflow_dispatch:
     inputs:
       package:
-        description: 'Package to publish'
+        description: "Package to publish"
         required: true
         type: choice
         options:
-          - '@vtex/ads-core'
-          - '@vtex/ads-react'
+          - "@vtex/ads-core"
+          - "@vtex/ads-react"
       version:
-        description: 'Package version (e.g. 1.2.3)'
+        description: "Package version (e.g. 1.2.3)"
         required: true
         type: string
       environment:
-        description: 'Environment (production or beta)'
+        description: "Environment (production or beta)"
         required: true
         type: choice
         options:
           - production
           - beta
       CA_TOKEN:
-        description: 'CodeArtifact Token'
+        description: "CodeArtifact Token"
         required: true
         type: string
       CA_OWNER:
-        description: 'CodeArtifact Domain Owner'
+        description: "CodeArtifact Domain Owner"
         required: true
         type: string
 
@@ -49,7 +49,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: '24'
+          node-version: "24"
 
       - name: Configure npm for CodeArtifact
         run: |

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -50,7 +50,13 @@ jobs:
         run: |
           set -euo pipefail
           TAG="${{ github.event.inputs.version }}"
-          # Tag format: @vtex/ads-core@0.5.2
+
+          if [[ ! "$TAG" =~ ^@vtex/(ads-core|ads-react)@[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9.-]+)?$ ]]; then
+            echo "Invalid tag format: $TAG"
+            echo "Expected: @vtex/ads-core@1.2.3 or @vtex/ads-react@1.2.3"
+            exit 1
+          fi
+
           # Extract package name (everything before the last @)
           PACKAGE_NAME="${TAG%@*}"
           # Extract version (everything after the last @)

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -1,0 +1,100 @@
+name: Publish from CodeArtifact to npm
+
+on:
+  workflow_dispatch:
+    inputs:
+      package:
+        description: 'Package to publish'
+        required: true
+        type: choice
+        options:
+          - '@vtex/ads-core'
+          - '@vtex/ads-react'
+      version:
+        description: 'Package version (e.g. 1.2.3)'
+        required: true
+        type: string
+      environment:
+        description: 'Environment (production or beta)'
+        required: true
+        type: choice
+        options:
+          - production
+          - beta
+      CA_TOKEN:
+        description: 'CodeArtifact Token'
+        required: true
+        type: string
+      CA_OWNER:
+        description: 'CodeArtifact Domain Owner'
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  id-token: write
+
+env:
+  CODEARTIFACT_DOMAIN: main
+  CODEARTIFACT_REPOSITORY: internal-npm
+  AWS_REGION: us-east-1
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+
+      - name: Configure npm for CodeArtifact
+        run: |
+          set -euo pipefail
+
+          export CODEARTIFACT_TOKEN="${{ github.event.inputs.CA_TOKEN }}"
+          export CODEARTIFACT_DOMAIN_OWNER="${{ github.event.inputs.CA_OWNER }}"
+
+          if [ -z "${CODEARTIFACT_TOKEN:-}" ]; then
+            echo "CODEARTIFACT_TOKEN not set"; exit 1
+          fi
+
+          CODEARTIFACT_URL="https://${CODEARTIFACT_DOMAIN}-${CODEARTIFACT_DOMAIN_OWNER}.d.codeartifact.${AWS_REGION}.amazonaws.com/npm/${CODEARTIFACT_REPOSITORY}/"
+
+          echo "Configuring npm to use ${CODEARTIFACT_URL}"
+
+          npm config set registry "${CODEARTIFACT_URL}"
+          npm config set "//${CODEARTIFACT_DOMAIN}-${CODEARTIFACT_DOMAIN_OWNER}.d.codeartifact.${AWS_REGION}.amazonaws.com/npm/${CODEARTIFACT_REPOSITORY}/:_authToken" "${CODEARTIFACT_TOKEN}"
+
+      - name: Download package from CodeArtifact
+        run: |
+          set -euo pipefail
+          NPM_PACKAGE_NAME="${{ github.event.inputs.package }}"
+          VERSION="${{ github.event.inputs.version }}"
+
+          echo "Downloading ${NPM_PACKAGE_NAME}@${VERSION} from CodeArtifact..."
+          npm pack "${NPM_PACKAGE_NAME}@${VERSION}"
+
+          echo "Generated files:"
+          ls -1 *.tgz
+
+      - name: Set npm registry to npmjs
+        run: |
+          set -euo pipefail
+          npm config set registry https://registry.npmjs.org
+          npm install -g npm@latest
+
+      - name: Publish tarball to npmjs
+        run: |
+          set -euo pipefail
+
+          TARBALL=$(ls -1 *.tgz | head -n 1)
+          TAG_FLAG=""
+          if [ "${{ github.event.inputs.environment }}" = "beta" ]; then
+            TAG_FLAG="--tag beta"
+          fi
+          echo "Publishing ${TARBALL} to npmjs..."
+          npm publish "${TARBALL}" --access public ${TAG_FLAG}

--- a/.vtex/deployment.yaml
+++ b/.vtex/deployment.yaml
@@ -10,7 +10,7 @@ pipelines:
         - build
       publishViaGithubWorkflow: true
       workflowFile: publish-npm.yml
-      workflowVersion: '{{ ref_name }}'
+      workflowVersion: "{{ ref_name }}"
     when:
       - event: push
         source: tag

--- a/.vtex/deployment.yaml
+++ b/.vtex/deployment.yaml
@@ -1,0 +1,16 @@
+apiVersion: vtex.io/v0
+application: T8O9XHQS
+pipelines:
+  - name: npm-publish-v1
+    parameters:
+      nodeVersion: "24-bookworm"
+      packageManager: pnpm
+      skipInstall: false
+      nodeCommands:
+        - build
+      publishViaGithubWorkflow: true
+      workflowFile: publish-npm.yml
+      workflowVersion: '{{ ref_name }}'
+    when:
+      - event: push
+        source: tag

--- a/README.md
+++ b/README.md
@@ -76,3 +76,48 @@ Comprehensive guides & API reference at <https://vtex.github.io/ads-js/docs>.
 
 Spin up the **playground** locally with `pnpm playground:dev` or try it online
 at <https://vtex.github.io/ads-js/>.
+
+## Release & Publishing
+
+This repo uses [Changesets](https://github.com/changesets/changesets) for versioning and the DK CI/CD `npm-publish-v1` pipeline for publishing to npm.
+
+### 1. Create a changeset
+
+After your change is merged, or as part of your PR:
+
+```bash
+pnpm changeset
+```
+
+Select the affected package(s), choose the bump type (`patch` / `minor` / `major`), and describe the change. This generates a file under `.changeset/` that should be committed alongside your code.
+
+### 2. Version packages
+
+Once the changeset PR is merged into `main`:
+
+```bash
+pnpm version-packages
+```
+
+This bumps the `package.json` versions and updates `CHANGELOG.md` for each affected package. Commit and push the result.
+
+### 3. Tag and trigger the pipeline
+
+Create and push a Git tag for each bumped package:
+
+```bash
+git tag @vtex/ads-core@<version>
+git push origin @vtex/ads-core@<version>
+```
+
+Pushing the tag triggers the `npm-publish-v1` pipeline, which builds the package and publishes it to AWS CodeArtifact.
+
+### 4. Publish to npm
+
+After the pipeline completes, go to **Actions → Publish from CodeArtifact to npm** and trigger it manually with:
+
+- **version**: the full tag name (e.g. `@vtex/ads-core@0.5.2`)
+- **CA_TOKEN** and **CA_OWNER**: provided by the pipeline run output
+- **environment**: `production` (default) or `beta`
+
+> **Prerequisite:** each package must have a [NPM Trusted Publisher](https://docs.npmjs.com/trusted-publishers) configured on npmjs.com pointing to this repo and the `publish-npm.yml` workflow. This is a one-time setup per package.

--- a/README.md
+++ b/README.md
@@ -106,8 +106,13 @@ This bumps the `package.json` versions and updates `CHANGELOG.md` for each affec
 Create and push a Git tag for each bumped package:
 
 ```bash
-git tag @vtex/ads-core@<version>
-git push origin @vtex/ads-core@<version>
+# Production release
+git tag @vtex/ads-core@1.2.3
+git push origin @vtex/ads-core@1.2.3
+
+# Beta release
+git tag @vtex/ads-core@1.2.3-beta.0
+git push origin @vtex/ads-core@1.2.3-beta.0
 ```
 
 Pushing the tag triggers the `npm-publish-v1` pipeline, which builds the package and publishes it to AWS CodeArtifact.


### PR DESCRIPTION
Sets up the DK CICD npm-publish-v1 pipeline and the GitHub workflow to publish @vtex/ads-core and @vtex/ads-react to the public npm registry via AWS CodeArtifact.