### PR TITLE
chore: release @vtex/ads-core@0.5.2 and @vtex/ads-react@0.5.1

### DIFF
--- a/.changeset/ads-react-bump-core.md
+++ b/.changeset/ads-react-bump-core.md
@@ -1,5 +1,0 @@
----
-"@vtex/ads-react": patch
----
-
-Bump @vtex/ads-core to pick up seller page context fix: seller pages now send context "search" instead of "home"

--- a/.changeset/seller-page-search-context.md
+++ b/.changeset/seller-page-search-context.md
@@ -1,5 +1,0 @@
----
-"@vtex/ads-core": patch
----
-
-Infer term from sellerName/seller facets when search.term is undefined, so seller pages send context "search" instead of "home"

--- a/README.md
+++ b/README.md
@@ -81,34 +81,24 @@ at <https://vtex.github.io/ads-js/>.
 
 This repo uses [Changesets](https://github.com/changesets/changesets) for versioning and the DK CI/CD `npm-publish-v1` pipeline for publishing to npm.
 
-### 1. Create a changeset
+### 1. Prepare the PR
 
-After your change is merged, or as part of your PR:
+In your feature branch, create the changeset and version in one go:
 
 ```bash
-pnpm changeset
+pnpm changeset        # describe the change and bump type
+pnpm version-packages # bump package.json, update CHANGELOG, delete the changeset file
 ```
 
-Select the affected package(s), choose the bump type (`patch` / `minor` / `major`), and describe the change. This generates a file under `.changeset/` that should be committed alongside your code.
+Open a single PR with everything: code changes, updated `package.json`, updated `CHANGELOG.md`.
 
-### 2. Version packages
+### 2. Tag and trigger the pipeline
 
-Once the changeset PR is merged into `main`, pull the latest and run:
+After the PR is merged, pull `main` and push a Git tag for each bumped package:
 
 ```bash
 git checkout main && git pull
-pnpm version-packages
-```
 
-This reads all pending changesets, bumps the `package.json` versions, updates `CHANGELOG.md`, and removes the consumed changeset files.
-
-**Open a separate PR** with this commit — `pnpm version-packages` must run after the changesets land on `main`, so it cannot be part of the same PR as the code change. After this PR is merged, proceed to step 3.
-
-### 3. Tag and trigger the pipeline
-
-Create and push a Git tag for each bumped package:
-
-```bash
 # Production release
 git tag @vtex/ads-core@1.2.3
 git push origin @vtex/ads-core@1.2.3
@@ -120,7 +110,7 @@ git push origin @vtex/ads-core@1.2.3-beta.0
 
 Pushing the tag triggers the `npm-publish-v1` pipeline, which builds the package and publishes it to AWS CodeArtifact.
 
-### 4. Publish to npm
+### 3. Publish to npm
 
 After the pipeline completes, go to **Actions → Publish from CodeArtifact to npm** and trigger it manually with:
 

--- a/README.md
+++ b/README.md
@@ -93,13 +93,16 @@ Select the affected package(s), choose the bump type (`patch` / `minor` / `major
 
 ### 2. Version packages
 
-Once the changeset PR is merged into `main`:
+Once the changeset PR is merged into `main`, pull the latest and run:
 
 ```bash
+git checkout main && git pull
 pnpm version-packages
 ```
 
-This bumps the `package.json` versions and updates `CHANGELOG.md` for each affected package. Commit and push the result.
+This reads all pending changesets, bumps the `package.json` versions, updates `CHANGELOG.md`, and removes the consumed changeset files.
+
+**Open a separate PR** with this commit — `pnpm version-packages` must run after the changesets land on `main`, so it cannot be part of the same PR as the code change. After this PR is merged, proceed to step 3.
 
 ### 3. Tag and trigger the pipeline
 

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @vtex/ads-core
 
+## 0.5.2
+
+### Patch Changes
+
+- fa11fc2: Infer term from sellerName/seller facets when search.term is undefined, so seller pages send context "search" instead of "home"
+
 ## 0.5.1
 
 ### Patch Changes

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@vtex/ads-core",
   "type": "module",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "scripts": {
     "build": "tsup",
     "clean": "rimraf dist",

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @vtex/ads-react
 
+## 0.5.1
+
+### Patch Changes
+
+- fa11fc2: Bump @vtex/ads-core to pick up seller page context fix: seller pages now send context "search" instead of "home"
+- Updated dependencies [fa11fc2]
+  - @vtex/ads-core@0.5.2
+
 ## 0.5.0
 
 ### Minor Changes

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@vtex/ads-react",
   "type": "module",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "main": "dist/cjs/index.cjs.js",
   "module": "dist/esm/index.js",
   "types": "dist/esm/index.d.ts",


### PR DESCRIPTION
Version bump generated by `pnpm version-packages` from changesets.

## Packages

- `@vtex/ads-core@0.5.2` — seller pages now send `context: "search"` instead of `context: "home"`
- `@vtex/ads-react@0.5.1` — picks up ads-core fix

After merge, push the tags to trigger the publish pipeline:

```bash
git tag @vtex/ads-core@0.5.2
git tag @vtex/ads-react@0.5.1
git push origin @vtex/ads-core@0.5.2
git push origin @vtex/ads-react@0.5.1
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)