### PR TITLE
chore: fix deployment.yaml structure for DK CI/CD

### DIFF
--- a/.vtex/deployment.yaml
+++ b/.vtex/deployment.yaml
@@ -1,16 +1,19 @@
-apiVersion: vtex.io/v0
-application: T8O9XHQS
-pipelines:
-  - name: npm-publish-v1
-    parameters:
-      nodeVersion: "24-bookworm"
-      packageManager: pnpm
-      skipInstall: false
-      nodeCommands:
-        - build
-      publishViaGithubWorkflow: true
-      workflowFile: publish-npm.yml
-      workflowVersion: "{{ ref_name }}"
-    when:
-      - event: push
-        source: tag
+projects:
+  - name: ads-js
+    referenceId: T8O9XHQS
+    build:
+      provider: dkcicd
+      pipelines:
+        - name: npm-publish-v1
+          parameters:
+            nodeVersion: "24-bookworm"
+            packageManager: pnpm
+            skipInstall: false
+            nodeCommands:
+              - build
+            publishViaGithubWorkflow: true
+            workflowFile: publish-npm.yml
+            workflowVersion: "{{ ref_name }}"
+          when:
+            - event: push
+              source: tag

--- a/.vtex/deployment.yaml
+++ b/.vtex/deployment.yaml
@@ -1,19 +1,18 @@
-projects:
-  - name: ads-js
-    referenceId: T8O9XHQS
-    build:
-      provider: dkcicd
-      pipelines:
-        - name: npm-publish-v1
-          parameters:
-            nodeVersion: "24-bookworm"
-            packageManager: pnpm
-            skipInstall: false
-            nodeCommands:
-              - build
-            publishViaGithubWorkflow: true
-            workflowFile: publish-npm.yml
-            workflowVersion: "{{ ref_name }}"
-          when:
-            - event: push
-              source: tag
+- name: ads-js
+  referenceId: T8O9XHQS
+  build:
+    provider: dkcicd
+    pipelines:
+      - name: npm-publish-v1
+        parameters:
+          nodeVersion: "24-bookworm"
+          packageManager: pnpm
+          skipInstall: false
+          nodeCommands:
+            - build
+          publishViaGithubWorkflow: true
+          workflowFile: publish-npm.yml
+          workflowVersion: "{{ ref_name }}"
+        when:
+          - event: push
+            source: tag


### PR DESCRIPTION
## Summary

- Fixes the `deployment.yaml` structure to match what DK CI/CD expects
- Changed from flat `application` / `pipelines` format to `projects[].referenceId` / `build.provider: dkcicd` / `pipelines` nesting
- This was likely causing the `npm-publish-v1` pipeline to not trigger on tag pushes

## Root cause

Our original format was based on an older/different doc. The correct structure (per DK AI) requires:

```yaml
projects:
  - name: ads-js
    referenceId: T8O9XHQS
    build:
      provider: dkcicd
      pipelines:
        - name: npm-publish-v1
```

After this is merged, re-push the tags `@vtex/ads-core@0.5.2` and `@vtex/ads-react@0.5.1` to trigger the pipeline.