### PR TITLE
chore: change tag format to ads-core-v0.5.2 (no slash)

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: "Full tag name (e.g. @vtex/ads-core@1.2.3)"
+        description: "Full tag name (e.g. ads-core-v1.2.3 or ads-react-v1.2.3)"
         required: true
         type: string
       environment:
@@ -51,16 +51,16 @@ jobs:
           set -euo pipefail
           TAG="${{ github.event.inputs.version }}"
 
-          if [[ ! "$TAG" =~ ^@vtex/(ads-core|ads-react)@[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9.-]+)?$ ]]; then
+          if [[ ! "$TAG" =~ ^(ads-core|ads-react)-v[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9.-]+)?$ ]]; then
             echo "Invalid tag format: $TAG"
-            echo "Expected: @vtex/ads-core@1.2.3 or @vtex/ads-react@1.2.3"
+            echo "Expected: ads-core-v1.2.3 or ads-react-v1.2.3"
             exit 1
           fi
 
-          # Extract package name (everything before the last @)
-          PACKAGE_NAME="${TAG%@*}"
-          # Extract version (everything after the last @)
-          PACKAGE_VERSION="${TAG##*@}"
+          # Extract short name (ads-core or ads-react) and version
+          SHORT_NAME="${TAG%-v*}"
+          PACKAGE_VERSION="${TAG#*-v}"
+          PACKAGE_NAME="@vtex/${SHORT_NAME}"
 
           echo "package_name=${PACKAGE_NAME}" >> $GITHUB_OUTPUT
           echo "package_version=${PACKAGE_VERSION}" >> $GITHUB_OUTPUT

--- a/.vtex/deployment.yaml
+++ b/.vtex/deployment.yaml
@@ -16,3 +16,4 @@
         when:
           - event: push
             source: tag
+            regex: ^(ads-core|ads-react)-v[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9.-]+)?$


### PR DESCRIPTION
## Summary

- Tags com `/` no nome (ex: `@vtex/ads-core@0.5.2`) criam refs aninhados no git (`refs/tags/@vtex/ads-core@0.5.2`) que o DK CI/CD webhook processor não consegue processar
- Novo formato: `ads-core-v1.2.3` e `ads-react-v1.2.3`
- `deployment.yaml`: adicionado `regex` no `when` para filtrar apenas tags no novo formato
- `publish-npm.yml`: atualizado parsing do tag → extrai `@vtex/ads-core` e versão `1.2.3`

## Após o merge

Recriar as tags no novo formato:
```bash
git tag ads-core-v0.5.2 && git push origin ads-core-v0.5.2
git tag ads-react-v0.5.1 && git push origin ads-react-v0.5.1
```