### PR TITLE
chore: test DK CI/CD connection (temporary)

### DIFF
--- a/.vtex/deployment.yaml
+++ b/.vtex/deployment.yaml
@@ -3,6 +3,17 @@
   build:
     provider: dkcicd
     pipelines:
+      - name: node-ci-v2
+        parameters:
+          nodeVersion: "24-bookworm"
+          packageManager: pnpm
+          skipInstall: false
+          nodeCommands:
+            - build
+        when:
+          - event: pull_request
+            source: branch
+
       - name: npm-publish-v1
         parameters:
           nodeVersion: "24-bookworm"


### PR DESCRIPTION
PR temporário para verificar se o DK CI/CD cria check runs em PRs do ads-js. Se aparecer 'DK CICD' na aba Checks, o webhook está conectado e o problema é só o trigger por tag.