### PR TITLE
fix: pack includes dist + ads-react build order

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -2,6 +2,12 @@
   "name": "@vtex/ads-core",
   "type": "module",
   "version": "0.5.2",
+  "files": [
+    "dist",
+    "src",
+    "README.md",
+    "CHANGELOG.md"
+  ],
   "scripts": {
     "build": "tsup",
     "clean": "rimraf dist",
@@ -10,7 +16,6 @@
     "test": "vitest"
   },
   "dependencies": {
-    "@swc/core": "^1.13.3",
     "cross-fetch": "^4.1.0"
   },
   "main": "dist/cjs/index.cjs.js",
@@ -53,6 +58,7 @@
   },
   "homepage": "https://github.com/vtex/ads-js/tree/main/packages/ads-core#readme",
   "devDependencies": {
+    "@swc/core": "^1.13.3",
     "tsup": "^8.5.0"
   }
 }

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -12,7 +12,14 @@
       "import": "./dist/esm/index.js"
     }
   },
+  "files": [
+    "dist",
+    "src",
+    "README.md",
+    "CHANGELOG.md"
+  ],
   "scripts": {
+    "prebuild": "pnpm --filter @vtex/ads-core run build",
     "build": "tsup",
     "clean": "rimraf dist",
     "dev": "tsc --watch",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -117,13 +117,13 @@ importers:
 
   packages/core:
     dependencies:
-      '@swc/core':
-        specifier: ^1.13.3
-        version: 1.13.3
       cross-fetch:
         specifier: ^4.1.0
         version: 4.1.0
     devDependencies:
+      '@swc/core':
+        specifier: ^1.13.3
+        version: 1.13.3
       tsup:
         specifier: ^8.5.0
         version: 8.5.0(@swc/core@1.13.3)(jiti@1.21.7)(postcss@8.5.6)(typescript@5.8.3)(yaml@2.8.0)


### PR DESCRIPTION
## Root causes

### Bug 1 — ads-core `pack-and-publish-ca` failed
`dist/` is in `.gitignore`. Without a `files` field or `.npmignore`, `pnpm pack` honors `.gitignore` and **excludes `dist/`**. The tarball sent to CodeArtifact had no built output.

**Fix:** add `files: ["dist", "src", "README.md", "CHANGELOG.md"]` to both packages.

### Bug 2 — ads-react `node-command` failed in 13s
DK runs `nodeCommands` from `contextPath` (`packages/react`). When tsup runs with `dts: true`, TypeScript tries to resolve `@vtex/ads-core` types from `packages/core/dist/esm/index.d.ts` — but `dist/` doesn't exist because ads-core hasn't been built yet in this isolated context.

**Fix:** add `"prebuild": "pnpm --filter @vtex/ads-core run build"` to ads-react scripts. npm/pnpm lifecycle hooks run `prebuild` automatically before `build`, so ads-core is built first.

### Bonus fix
`@swc/core` was in `dependencies` instead of `devDependencies`. It's a TypeScript compiler used only at build time — it was being installed unnecessarily by consumers of `@vtex/ads-core`.

## Changes
- `packages/core/package.json`: add `files`, move `@swc/core` to devDeps
- `packages/react/package.json`: add `files`, add `prebuild` script

## Test plan
- [ ] Merge this PR
- [ ] Push tag `v0.5.2` (delete and re-create, or use `v0.5.3` if preferred)
- [ ] Confirm DK triggers both pipelines → both `node-command` steps pass
- [ ] Confirm both `pack-and-publish-ca` steps pass
- [ ] Confirm `@vtex/ads-core@0.5.2` and `@vtex/ads-react@0.5.2` published to npm

🤖 Generated with [Claude Code](https://claude.com/claude-code)