### PR TITLE
chore: bump to 0.5.3

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @vtex/ads-core
 
+## 0.5.3
+
+### Patch Changes
+
+- Version bump to retrigger publish pipeline with corrected pack configuration
+
 ## 0.5.2
 
 ### Patch Changes

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@vtex/ads-core",
   "type": "module",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "files": [
     "dist",
     "src",

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @vtex/ads-react
 
+## 0.5.3
+
+### Patch Changes
+
+- Version bump to retrigger publish pipeline with corrected pack configuration
+
 ## 0.5.2
 
 ### Patch Changes

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@vtex/ads-react",
   "type": "module",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "main": "dist/cjs/index.cjs.js",
   "module": "dist/esm/index.js",
   "types": "dist/esm/index.d.ts",


### PR DESCRIPTION
## Summary

- Bump `@vtex/ads-core` and `@vtex/ads-react` from `0.5.2` to `0.5.3`

`0.5.2` never reached npm due to pipeline issues fixed in PRs #40 and #41. Using `0.5.3` to avoid potential version conflicts in CodeArtifact.

## After merging

```bash
git checkout main && git pull
git tag v0.5.3
git push origin v0.5.3
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)