### PR TITLE
fix: typesVersions paths + ads-docs build order

### DIFF
--- a/packages/ads-docs/package.json
+++ b/packages/ads-docs/package.json
@@ -27,6 +27,8 @@
     "@docusaurus/module-type-aliases": "3.8.1",
     "@docusaurus/tsconfig": "3.8.1",
     "@docusaurus/types": "3.8.1",
+    "@vtex/ads-core": "workspace:^",
+    "@vtex/ads-react": "workspace:^",
     "typescript": "~5.6.2"
   },
   "browserslist": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -41,10 +41,10 @@
   "typesVersions": {
     "*": {
       "adServer": [
-        "./dist/clients/adServer/index.d.ts"
+        "./dist/esm/clients/adServer/index.d.ts"
       ],
       "search": [
-        "./dist/clients/search/index.d.ts"
+        "./dist/esm/clients/search/index.d.ts"
       ]
     }
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -111,6 +111,12 @@ importers:
       '@docusaurus/types':
         specifier: 3.8.1
         version: 3.8.1(acorn@8.15.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@vtex/ads-core':
+        specifier: workspace:^
+        version: link:../core
+      '@vtex/ads-react':
+        specifier: workspace:^
+        version: link:../react
       typescript:
         specifier: ~5.6.2
         version: 5.6.3


### PR DESCRIPTION
## Summary

Fixes the pre-existing CI failure in `ads-docs:build`.

### Root causes

**1. Wrong `typesVersions` paths in `@vtex/ads-core`**

`typesVersions` pointed to `./dist/clients/adServer/index.d.ts` but tsup outputs declarations to `./dist/esm/clients/adServer/index.d.ts`. TypeDoc (used by `ads-docs`) and TypeScript resolvers that fall back to `typesVersions` couldn't find the `.d.ts` for the `/adServer` and `/search` subpaths.

**2. Turbo build ordering**

`ads-docs` didn't list `@vtex/ads-core` or `@vtex/ads-react` as dependencies, so Turbo could start `ads-docs:build` in parallel with the packages on cold cache — before their types were generated.

### Changes
- `packages/core/package.json`: `./dist/clients/` → `./dist/esm/clients/` in `typesVersions`
- `packages/ads-docs/package.json`: add `@vtex/ads-core` and `@vtex/ads-react` as `devDependencies` so Turbo waits for them before starting the docs build

🤖 Generated with [Claude Code](https://claude.com/claude-code)