### PR TITLE
fix: move pnpm settings to pnpm-workspace.yaml

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,14 +24,6 @@
   "author": "",
   "license": "UNLICENSED",
   "packageManager": "pnpm@10.14.0",
-  "pnpm": {
-    "onlyBuiltDependencies": [
-      "@swc/core",
-      "core-js",
-      "core-js-pure",
-      "esbuild"
-    ]
-  },
   "devDependencies": {
     "@changesets/changelog-github": "^0.5.1",
     "@changesets/cli": "^2.29.5",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,5 +1,13 @@
 packages:
-  - 'packages/core'
-  - 'packages/react'
-  - 'packages/playground'
-  - 'packages/ads-docs'
+  - "packages/core"
+  - "packages/react"
+  - "packages/playground"
+  - "packages/ads-docs"
+
+onlyBuiltDependencies:
+  - "@swc/core"
+  - core-js
+  - core-js-pure
+  - esbuild
+
+managePackageManagerVersions: false


### PR DESCRIPTION
## Root cause

The DK pod uses pnpm v10.9+ which no longer reads settings from `package.json["pnpm"]`:
```
[WARN] The "pnpm" field in package.json is no longer read by pnpm.
The following keys were ignored: "pnpm.onlyBuiltDependencies".
See https://pnpm.io/settings for the new home of each setting.
```

Similarly, `manage-package-manager-versions=false` in `.npmrc` was not being applied for `@pnpm/exe` downloads.

## Fix

Move settings to `pnpm-workspace.yaml` (the correct location for pnpm v10.9+):
- `onlyBuiltDependencies` — prevents `ERR_PNPM_IGNORED_BUILDS`
- `managePackageManagerVersions: false` — prevents pnpm from fetching `@pnpm/exe` from CodeArtifact when DK runs `pnpm publish --registry <CodeArtifact>`

## After merging

Delete and recreate `v0.5.3` tag to retrigger DK pipelines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)