### PR TITLE
fix: pnpm@11 compatibility — pmOnFail: ignore para DK CI

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,2 @@
 manage-package-manager-versions=false
+pm-on-fail=ignore

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,10 +4,21 @@ packages:
   - "packages/playground"
   - "packages/ads-docs"
 
+# pnpm@10
 onlyBuiltDependencies:
   - "@swc/core"
   - core-js
   - core-js-pure
   - esbuild
 
+# pnpm@11
+allowBuilds:
+  "@swc/core": true
+  core-js: true
+  core-js-pure: true
+  esbuild: true
+
+# pnpm@10: desabilita gerenciamento de versão
 managePackageManagerVersions: false
+# pnpm@11: ignora mismatch de versão (DK instala pnpm@latest, nosso packageManager é pnpm@10.x)
+pmOnFail: ignore


### PR DESCRIPTION
## Root cause

DK's `npm-pack-and-publish-ca-v1` task instala pnpm via `npm install -g pnpm`, que agora instala **pnpm@11.6.0** (major upgrade do 10.x).

Em pnpm@11, as configurações anteriores foram removidas:
- `managePackageManagerVersions` → substituído por `pmOnFail`
- `onlyBuiltDependencies` → substituído por `allowBuilds`

Sem `pmOnFail`, o default do pnpm@11 é `download` — tentando baixar `@pnpm/exe@10.14.0` do CodeArtifact e falhando com 401 Unauthorized.

## Changes

- `pnpm-workspace.yaml`: adiciona `pmOnFail: ignore` e `allowBuilds` (pnpm@11), mantém as configs de pnpm@10 para compatibilidade local
- `.npmrc`: adiciona `pm-on-fail=ignore` como fallback

## Test plan

- [ ] Build local: `pnpm build` ✅
- [ ] Format: `pnpm format` ✅
- [ ] Lint: `pnpm lint` ✅
- [ ] Merge, recriar tag `v0.5.3`, confirmar DK `pack-and-publish-ca` OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)