### PR TITLE
fix: propagate auth token para pnpm@11 no prepack

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -9,6 +9,7 @@
     "CHANGELOG.md"
   ],
   "scripts": {
+    "prepack": "node -e \"const fs=require('fs'),p=require('path'),o=require('os');try{let t='';for(const f of[p.join(o.homedir(),'.npmrc'),'.npmrc']){try{const ls=fs.readFileSync(f,'utf8').split('\\n').filter(l=>l.includes('_authToken')&&l.trim());if(ls.length){t=ls[0];break}}catch(e){}}if(t){const tA=t.replace('/:_authToken',':_authToken');const c='\\nalways-auth=true\\n'+t+'\\n'+(t!==tA?tA+'\\n':'');try{fs.appendFileSync('../../.npmrc',c)}catch(e){}try{const d=p.join(o.homedir(),'.config','pnpm');fs.mkdirSync(d,{recursive:true});fs.appendFileSync(p.join(d,'auth.ini'),c)}catch(e){}}}catch(e){}\"",
     "build": "tsup",
     "clean": "rimraf dist",
     "dev": "tsc --watch",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -19,6 +19,7 @@
     "CHANGELOG.md"
   ],
   "scripts": {
+    "prepack": "node -e \"const fs=require('fs'),p=require('path'),o=require('os');try{let t='';for(const f of[p.join(o.homedir(),'.npmrc'),'.npmrc']){try{const ls=fs.readFileSync(f,'utf8').split('\\n').filter(l=>l.includes('_authToken')&&l.trim());if(ls.length){t=ls[0];break}}catch(e){}}if(t){const tA=t.replace('/:_authToken',':_authToken');const c='\\nalways-auth=true\\n'+t+'\\n'+(t!==tA?tA+'\\n':'');try{fs.appendFileSync('../../.npmrc',c)}catch(e){}try{const d=p.join(o.homedir(),'.config','pnpm');fs.mkdirSync(d,{recursive:true});fs.appendFileSync(p.join(d,'auth.ini'),c)}catch(e){}}}catch(e){}\"",
     "prebuild": "pnpm --filter @vtex/ads-core run build",
     "build": "tsup",
     "clean": "rimraf dist",


### PR DESCRIPTION
## Root cause

pnpm@11 tem um cliente HTTP nativo para publish (não delega mais para npm). O DK escreve o auth token apenas em `~/.npmrc`, mas pnpm@11 prioriza `~/.config/pnpm/auth.ini` e workspace root `.npmrc` — não encontra o token em `~/.npmrc` durante o publish.

## Fix

Adiciona `prepack` lifecycle hook em `packages/core` e `packages/react` que:
1. Lê o `_authToken` de `~/.npmrc` (onde o DK escreve) ou `.npmrc` local
2. Copia para workspace root `.npmrc` (verificado pelo pnpm@11 como project-level config)
3. Copia para `~/.config/pnpm/auth.ini` (novo local de auth do pnpm@11)
4. Inclui ambos os formatos de chave: `//registry/:_authToken` e `//registry:_authToken` (trailing slash inconsistency)

O prepack roda **antes** de `pnpm pack` e **antes** de `pnpm publish`, então o auth já estará disponível quando o HTTP request for feito.

Localmente é no-op (nenhum `_authToken` nos `.npmrc` locais = não copia nada).

## Test plan

- [ ] Build local: `pnpm build` ✅
- [ ] Format: `pnpm format` ✅  
- [ ] Lint: `pnpm lint` ✅
- [ ] Merge, recriar tag `v0.5.3`, confirmar `pack-and-publish-ca` completo

🤖 Generated with [Claude Code](https://claude.com/claude-code)