### PR TITLE
fix: add version input and OIDC provenance to publish workflows

### DIFF
--- a/.github/workflows/publish-core.yml
+++ b/.github/workflows/publish-core.yml
@@ -3,6 +3,10 @@ name: Publish ads-core to npm
 on:
   workflow_dispatch:
     inputs:
+      version:
+        description: "Version being published (sent by DK pipeline)"
+        required: false
+        type: string
       environment:
         description: "Environment (production or beta)"
         required: false
@@ -40,6 +44,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: "24"
+          registry-url: https://registry.npmjs.org
 
       - name: Read package version
         id: pkg
@@ -73,4 +78,4 @@ jobs:
           if [ "${{ github.event.inputs.environment }}" = "beta" ]; then
             TAG_FLAG="--tag beta"
           fi
-          npm publish "${TARBALL}" --access public ${TAG_FLAG}
+          npm publish "${TARBALL}" --access public --provenance ${TAG_FLAG}

--- a/.github/workflows/publish-react.yml
+++ b/.github/workflows/publish-react.yml
@@ -3,6 +3,10 @@ name: Publish ads-react to npm
 on:
   workflow_dispatch:
     inputs:
+      version:
+        description: "Version being published (sent by DK pipeline)"
+        required: false
+        type: string
       environment:
         description: "Environment (production or beta)"
         required: false
@@ -40,6 +44,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: "24"
+          registry-url: https://registry.npmjs.org
 
       - name: Read package version
         id: pkg
@@ -73,4 +78,4 @@ jobs:
           if [ "${{ github.event.inputs.environment }}" = "beta" ]; then
             TAG_FLAG="--tag beta"
           fi
-          npm publish "${TARBALL}" --access public ${TAG_FLAG}
+          npm publish "${TARBALL}" --access public --provenance ${TAG_FLAG}


### PR DESCRIPTION
## Summary

- Add `version` input to `workflow_dispatch` (DK sends it; GitHub was rejecting the dispatch with 422)
- Add `registry-url: https://registry.npmjs.org` to `setup-node` (required for OIDC endpoint)
- Add `--provenance` flag to `npm publish` (activates OIDC token exchange with npmjs Trusted Publisher)

## Context

DK `github-workflow-dispatch-send-version-v1` task sends `version`, `environment`, `CA_TOKEN`, and `CA_OWNER` as inputs. Both publish workflows only defined the last three — GitHub silently rejected the dispatch. Also, npmjs Trusted Publisher (OIDC) requires `registry-url` and `--provenance` to be set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)