### PR TITLE
chore: bump ads-core and ads-react to 0.5.4

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@vtex/ads-core",
   "type": "module",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "files": [
     "dist",
     "src",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@vtex/ads-react",
   "type": "module",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "main": "dist/cjs/index.cjs.js",
   "module": "dist/esm/index.js",
   "types": "dist/esm/index.d.ts",


### PR DESCRIPTION
Bump version to 0.5.4 — 0.5.3 already exists in CodeArtifact (from previous successful DK run), causing 409 on republish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)